### PR TITLE
enable Postgres error detail

### DIFF
--- a/Jellyfin.Plugin.Pgsql/Database/PgSqlDatabaseProvider.cs
+++ b/Jellyfin.Plugin.Pgsql/Database/PgSqlDatabaseProvider.cs
@@ -240,7 +240,8 @@ public sealed class PgSqlDatabaseProvider : IJellyfinDatabaseProvider
             Port = int.Parse(Environment.GetEnvironmentVariable("POSTGRES_PORT") ?? "5432", CultureInfo.InvariantCulture),
             Database = Environment.GetEnvironmentVariable("POSTGRES_DB") ?? "jellyfin",
             Username = Environment.GetEnvironmentVariable("POSTGRES_USER") ?? "jellyfin",
-            Password = Environment.GetEnvironmentVariable("POSTGRES_PASSWORD") ?? throw new InvalidOperationException("PostgreSQL password must be provided via POSTGRES_PASSWORD environment variable")
+            Password = Environment.GetEnvironmentVariable("POSTGRES_PASSWORD") ?? throw new InvalidOperationException("PostgreSQL password must be provided via POSTGRES_PASSWORD environment variable"),
+            IncludeErrorDetail = true
         };
 
         return connectionBuilder;


### PR DESCRIPTION
Enable Postgres error detail reporting to enable troubleshooting, e.g. primary key violations.  This is disabled by default in Npgsql because it can log database data, which in some contexts could be confidential.