### PR TITLE
Enable access to EF Core EnableSensitiveDataLogging

### DIFF
--- a/Jellyfin.Plugin.Pgsql/Database/PgSqlDatabaseProvider.cs
+++ b/Jellyfin.Plugin.Pgsql/Database/PgSqlDatabaseProvider.cs
@@ -51,6 +51,11 @@ public sealed class PgSqlDatabaseProvider : IJellyfinDatabaseProvider
             {
                 pgSqlOptions.MigrationsAssembly(GetType().Assembly.FullName);
             });
+
+        if (bool.TryParse(Environment.GetEnvironmentVariable("EFCORE_ENABLE_SENSITIVE_DATA_LOGGING"), out bool enableSensitiveDataLogging))
+        {
+            options.EnableSensitiveDataLogging(enableSensitiveDataLogging);
+        }
     }
 
     /// <inheritdoc/>

--- a/Jellyfin.Plugin.Pgsql/Database/PgSqlDatabaseProvider.cs
+++ b/Jellyfin.Plugin.Pgsql/Database/PgSqlDatabaseProvider.cs
@@ -41,7 +41,7 @@ public sealed class PgSqlDatabaseProvider : IJellyfinDatabaseProvider
     public IDbContextFactory<JellyfinDbContext>? DbContextFactory { get; set; }
 
     /// <inheritdoc/>
-    public void Initialise(DbContextOptionsBuilder options)
+    public void Initialise(DbContextOptionsBuilder options, DatabaseConfigurationOptions databaseConfiguration)
     {
         var connectionBuilder = GetConnectionBuilder();
         connectionBuilder.ApplicationName = $"jellyfin+{FileVersionInfo.GetVersionInfo(Assembly.GetEntryAssembly()!.Location).FileVersion}";

--- a/Jellyfin.Plugin.Pgsql/Jellyfin.Plugin.Pgsql.csproj
+++ b/Jellyfin.Plugin.Pgsql/Jellyfin.Plugin.Pgsql.csproj
@@ -11,9 +11,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jellyfin.Controller" Version="10.11.0-rc3" PrivateAssets="all" />
-    <PackageReference Include="Jellyfin.Model" Version="10.11.0-rc3" PrivateAssets="all" />
-
+    <PackageReference Include="Jellyfin.Controller" Version="10.11.0-rc4" PrivateAssets="all" />
+    <PackageReference Include="Jellyfin.Model" Version="10.11.0-rc4" PrivateAssets="all" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
     <PackageReference Include="Npgsql" Version="9.0.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Abstractions" Version="9.0.7" PrivateAssets="all" />


### PR DESCRIPTION
Use environment variable EFCORE_ENABLE_SENSITIVE_DATA_LOGGING to set options.EnableSensitiveDataLogging.

Useful for troubleshooting.