### PR TITLE
fix syntax error for CreateIndex filters

### DIFF
--- a/Jellyfin.Plugin.Pgsql/Migrations/20250929202529_Update_10.11-RC8.cs
+++ b/Jellyfin.Plugin.Pgsql/Migrations/20250929202529_Update_10.11-RC8.cs
@@ -27,14 +27,14 @@ namespace Jellyfin.Plugin.Pgsql.Migrations
                 table: "Preferences",
                 columns: ["UserId", "Kind"],
                 unique: true,
-                filter: "[UserId] IS NOT NULL");
+                filter: "\"UserId\" IS NOT NULL");
 
             migrationBuilder.CreateIndex(
                 name: "IX_Permissions_UserId_Kind",
                 table: "Permissions",
                 columns: ["UserId", "Kind"],
                 unique: true,
-                filter: "[UserId] IS NOT NULL");
+                filter: "\"UserId\" IS NOT NULL");
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
This fixes an error in `Jellyfin.Plugin.Pgsql/Migrations/20250929202529_Update_10.11-RC8.cs` where the filters where not properly formatted syntactically causing the migration to error out and fail.