### PR TITLE
Fix pg_dump/psql startup deadlock from undrained output pipes (#39)

### DIFF
--- a/Jellyfin.Plugin.Pgsql/Database/PgSqlDatabaseProvider.cs
+++ b/Jellyfin.Plugin.Pgsql/Database/PgSqlDatabaseProvider.cs
@@ -146,11 +146,18 @@ public sealed class PgSqlDatabaseProvider : IJellyfinDatabaseProvider
         _logger.LogInformation("Starting PostgreSQL backup: {BackupFile}", backupFile);
 
         process.Start();
+
+        // Read both pipes while pg_dump runs. Its --verbose output goes to stderr,
+        // and leaving the redirected pipe unread will deadlock once it fills
+        // (JPVenson/Jellyfin.Pgsql#39).
+        var stdoutTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
+        var stderrTask = process.StandardError.ReadToEndAsync(cancellationToken);
         await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+        await stdoutTask.ConfigureAwait(false);
+        var error = await stderrTask.ConfigureAwait(false);
 
         if (process.ExitCode != 0)
         {
-            var error = await process.StandardError.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
             _logger.LogError("pg_dump failed with exit code {ExitCode}: {Error}", process.ExitCode, error);
             throw new InvalidOperationException($"pg_dump failed: {error}");
         }
@@ -190,11 +197,17 @@ public sealed class PgSqlDatabaseProvider : IJellyfinDatabaseProvider
         _logger.LogInformation("Starting PostgreSQL restore from: {BackupFile}", backupFile);
 
         process.Start();
+
+        // Same reason as MigrationBackupFast: read the pipes while psql runs so a
+        // large restore can't fill the redirected output buffer and deadlock.
+        var stdoutTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
+        var stderrTask = process.StandardError.ReadToEndAsync(cancellationToken);
         await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+        await stdoutTask.ConfigureAwait(false);
+        var error = await stderrTask.ConfigureAwait(false);
 
         if (process.ExitCode != 0)
         {
-            var error = await process.StandardError.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
             _logger.LogError("psql restore failed with exit code {ExitCode}: {Error}", process.ExitCode, error);
             throw new InvalidOperationException($"psql restore failed: {error}");
         }


### PR DESCRIPTION
Fixes #39. After upgrading an existing instance to 10.11.11-1 the server hangs at startup, stuck logging `Starting PostgreSQL backup:` and "Server is still starting up", and never finishes.

The backup and restore helpers redirect the child process's stdout and stderr but only read them after it exits (stderr only in the failure branch). `pg_dump` runs with `--verbose`, which writes one progress line per database object to stderr. Once that output fills the OS pipe buffer (~64 KB on Linux) `pg_dump` blocks on the write and `WaitForExitAsync` never returns.

The output scales with the number of objects, not row count, so it isn't about library size. A bare schema is about 25 KB of `--verbose` stderr and stays under the buffer, which is why a fresh install boots fine. For example, server plugins that store data add their own tables and indexes; with enough objects the output crosses 64 KB and the backup deadlocks.

The fix reads both streams concurrently while the process runs, in `MigrationBackupFast` and `RestoreBackupFast` (restore has the same pattern).

Verified end to end with the real `pg_dump` against a database with 200 tables (~140 KB of `--verbose` stderr), running the exact released vs fixed code paths:
- released pattern: hangs, killed after a 25 s timeout, only a partial dump on disk
- this fix: completes in ~150 ms with a full dump

`dotnet build` is clean (0 warnings).
