### PR TITLE
Add POSTGRES_COMMAND_TIMEOUT to configure the command timeout

### DIFF
--- a/Jellyfin.Plugin.Pgsql/Database/PgSqlDatabaseProvider.cs
+++ b/Jellyfin.Plugin.Pgsql/Database/PgSqlDatabaseProvider.cs
@@ -276,7 +276,11 @@ public sealed class PgSqlDatabaseProvider : IJellyfinDatabaseProvider
             Port = int.Parse(Environment.GetEnvironmentVariable("POSTGRES_PORT") ?? "5432", CultureInfo.InvariantCulture),
             Database = Environment.GetEnvironmentVariable("POSTGRES_DB") ?? "jellyfin",
             Username = Environment.GetEnvironmentVariable("POSTGRES_USER") ?? "jellyfin",
-            Password = Environment.GetEnvironmentVariable("POSTGRES_PASSWORD") ?? throw new InvalidOperationException("PostgreSQL password must be provided via POSTGRES_PASSWORD environment variable")
+            Password = Environment.GetEnvironmentVariable("POSTGRES_PASSWORD") ?? throw new InvalidOperationException("PostgreSQL password must be provided via POSTGRES_PASSWORD environment variable"),
+
+            // Command timeout in seconds (0 = no limit). Defaults to Npgsql's 30s.
+            // Raise it via POSTGRES_COMMAND_TIMEOUT for slow queries on large libraries.
+            CommandTimeout = int.Parse(Environment.GetEnvironmentVariable("POSTGRES_COMMAND_TIMEOUT") ?? "30", CultureInfo.InvariantCulture)
         };
 
         if (includeErrorDetail)

--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ services:
       # Optional settings bellow, uncomment if you want to connect using SSL
       # - POSTGRES_SSLMODE=Require
       # - POSTGRES_TRUSTSERVERCERTIFICATE=true
+      # Optional: per-command timeout in seconds (default 30, 0 = no limit).
+      # Raise it if large libraries hit query timeouts.
+      # - POSTGRES_COMMAND_TIMEOUT=120
 ```
 
 # Build


### PR DESCRIPTION
The connection string is built entirely from `POSTGRES_*` env vars, so the Npgsql command timeout is stuck at the 30s default with no way to change it: a connection-string `Command Timeout` has no effect because the plugin builds its own string. On large libraries a slow query can exceed 30s and fail, e.g. #35 where `/Items/Latest` returns HTTP 500 at exactly the 30s mark.

Adds `POSTGRES_COMMAND_TIMEOUT` (seconds, `0` = no limit). Defaults to 30, so behaviour is unchanged unless set. This mitigates #35 by letting users raise the timeout so the query completes instead of erroring; the underlying query slowness is a separate (core) problem.

Verified on a running instance: with `POSTGRES_COMMAND_TIMEOUT=5` the connection string becomes `...;Command Timeout=5`, and a query made to block past 5s (table lock) is cancelled at ~5.4s instead of the 30s default.

